### PR TITLE
Silence ArgumentErrors

### DIFF
--- a/lib/mongo-parser-rb/query/expression.rb
+++ b/lib/mongo-parser-rb/query/expression.rb
@@ -134,6 +134,8 @@ module MongoParserRB
             @arguments.include?(value_for_field)
           end
         end
+      rescue ArgumentError
+        false
       end
     end
   end

--- a/test/mongo-parser-rb/query_test.rb
+++ b/test/mongo-parser-rb/query_test.rb
@@ -191,4 +191,9 @@ class QueryTest < MiniTest::Unit::TestCase
     assert query.matches_document?(:array_key => [1,2])
   end
 
+  def test_datatype_mismatch
+    query = MongoParserRB::Query.parse(:integer_key => {:$gt => 5})
+    refute query.matches_document?(:integer_key => "hello")
+  end
+    
 end


### PR DESCRIPTION
This is to stop MongoParserRB from crashing when asked to compare different data types — returns false instead (what MongoDB does).
