### PR TITLE
reduce stringify keys usage

### DIFF
--- a/lib/mongo-parser-rb/field.rb
+++ b/lib/mongo-parser-rb/field.rb
@@ -7,7 +7,6 @@ module MongoParserRB
     end
 
     def value_in_document(document)
-      document = stringify_keys(document)
       @field_parts.reduce(document) do |value, field|
         case value
         when Array
@@ -22,31 +21,12 @@ module MongoParserRB
     end
 
     def in_document?(document)
-      document = stringify_keys(document)
-
       @field_parts.reduce(document) do |value, field|
         return false unless value.has_key?(field)
         value[field]
       end
 
       true
-    end
-
-    private
-
-    def stringify_keys(document)
-      document.reduce({}) do |new_document, (k,v)|
-        new_document[k.to_s] = case v
-        when Hash
-          stringify_keys(v)
-        when Array
-          v.map { |e| e.kind_of?(Hash) ? stringify_keys(e) : e }
-        else
-          v
-        end
-
-        new_document
-      end
     end
 
   end

--- a/test/mongo-parser-rb/field_test.rb
+++ b/test/mongo-parser-rb/field_test.rb
@@ -1,41 +1,41 @@
 require 'test_helper'
 
-class FieldTest < MiniTest::Unit::TestCase
+class FieldTest < Minitest::Test
 
   def test_returns_value_when_key_present
     field = MongoParserRB::Field.new(:"custom_data.tracked_users")
-    assert_equal 10, field.value_in_document(:custom_data => {:tracked_users => 10})
+    assert_equal 10, field.value_in_document('custom_data' => {'tracked_users' => 10})
   end
 
   def test_returns_nil_when_key_not_present
     field = MongoParserRB::Field.new(:"custom_data.tracked_users")
-    assert_nil field.value_in_document(:custom_data => {:something_else => 10})
-    assert_nil field.value_in_document(:name => "Ben")
+    assert_nil field.value_in_document('custom_data' => {'something_else' => 10})
+    assert_nil field.value_in_document('name' => "Ben")
   end
 
   def test_document_has_a_field
     field = MongoParserRB::Field.new(:"custom_data.tracked_users")
-    assert field.in_document?(:custom_data => {:tracked_users => 10})
-    refute field.in_document?(:not_custom_data => {:tracked_users => 10})
+    assert field.in_document?('custom_data' => {'tracked_users' => 10})
+    refute field.in_document?('not_custom_data' => {'tracked_users' => 10})
 
     field = MongoParserRB::Field.new(:"session_count")
-    assert field.in_document?(:custom_data => {:tracked_users => 10}, :session_count => 5)
-    refute field.in_document?(:custom_data => {:tracked_users => 10})
+    assert field.in_document?('custom_data' => {'tracked_users' => 10}, 'session_count' => 5)
+    refute field.in_document?('custom_data' => {'tracked_users' => 10})
   end
 
   def test_returning_array_element
     field = MongoParserRB::Field.new(:"something.array.0")
-    assert_equal 1, field.value_in_document(:something => {:array => [1,2]})
+    assert_equal 1, field.value_in_document('something' => {'array' => [1,2]})
   end
-  
+
   def test_returning_empty_array
     field = MongoParserRB::Field.new(:"something.array.name")
-    assert_equal [], field.value_in_document(:something => {:array => []})
+    assert_equal [], field.value_in_document('something' => {'array' => []})
   end
 
   def test_returning_hash_in_array
     field = MongoParserRB::Field.new(:"something.array.0.key")
-    document = {:something => {:array => [{:key => 'hello world'}, {:key => 'bye world'}]}}
+    document = {'something' => {'array' => [{'key' => 'hello world'}, {'key' => 'bye world'}]}}
     assert_equal 'hello world', field.value_in_document(document)
 
     field = MongoParserRB::Field.new(:"something.array.1.key")

--- a/test/mongo-parser-rb/query_test.rb
+++ b/test/mongo-parser-rb/query_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class QueryTest < MiniTest::Unit::TestCase
+class QueryTest < Minitest::Test
   def test_raises_if_not_parsed
     assert_raises(MongoParserRB::NotParsedError) do
       query = MongoParserRB::Query.new(:integer_key => 10)
@@ -149,12 +149,12 @@ class QueryTest < MiniTest::Unit::TestCase
     refute query.matches_document?(:array_key => [1,4,5])
   end
 
-  def test_nil_by_absence_nin 
+  def test_nil_by_absence_nin
     query = MongoParserRB::Query.parse(:"custom_data.value" => {:$nin => [nil]})
     assert query.matches_document?(:custom_data => {:value => 5})
     refute query.matches_document?({})
   end
-  
+
   def test_nil_by_empty
     query = MongoParserRB::Query.parse({:"user_event_summaries.name" => {:$ne => "second-support"}})
     assert query.matches_document?({"user_event_summaries" => []})
@@ -236,19 +236,19 @@ class QueryTest < MiniTest::Unit::TestCase
     query = MongoParserRB::Query.parse(:array_key => {:$ne => [1]})
     assert query.matches_document?(:array_key => [1,2])
   end
-  
+
   def test_elemMatch
     query = MongoParserRB::Query.parse({:user_event_summaries => {:$elemMatch=> {:name => "second-support", :count => 3}}})
     refute query.matches_document?(:user_event_summaries => [{:name => "first-support", :count => 3}, {:name => "second-support", :count => 4}])
     assert query.matches_document?(:user_event_summaries => [{:name => "first-support", :count => 4}, {:name => "second-support", :count => 3}])
   end
-  
+
   def test_elemMatch_inequality
     query = MongoParserRB::Query.parse(:user_event_summaries => {:$elemMatch=> {:count => {:$ne => 2}, :name => "second-support"}})
     refute query.matches_document?(:user_event_summaries => [{:name => "first-support", :count => 3}, {:name => "second-support", :count => 2}])
     assert query.matches_document?(:user_event_summaries => [{:name => "first-support", :count => 3}, {:name => "second-support", :count => 3}])
   end
-  
+
   def test_datatype_mismatch
     query = MongoParserRB::Query.parse(:integer_key => {:$gt => 5})
     refute query.matches_document?(:integer_key => "hello")


### PR DESCRIPTION
I'll rebase this once https://github.com/intercom/mongo-parser-rb/pull/10 has merged to remove the perf changes.

**before**

```
➜  mongo-parser-rb git:(gj/perf) rake perf
                             user     system      total        real
simple query parsing    18.770000   0.050000  18.820000 ( 18.920121)
simple query matching   42.400000   0.090000  42.490000 ( 42.751880)
```

**after**

```
➜  mongo-parser-rb git:(gj/reduce-stringify-keys-usage) rake perf
                             user     system      total        real
simple query parsing    18.440000   0.040000  18.480000 ( 18.579421)
simple query matching   15.030000   0.030000  15.060000 ( 15.128386)
```

/cc @dehora @ciaranlee 