### PR TITLE
query parser perf

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,3 +9,9 @@ Rake::TestTask.new("test") do |test|
   test.warning = false
   test.verbose = true
 end
+
+
+desc "Run some performance tests"
+task :perf do
+  require_relative 'performance/perf.rb'
+end

--- a/lib/mongo-parser-rb.rb
+++ b/lib/mongo-parser-rb.rb
@@ -1,8 +1,8 @@
-require "mongo-parser-rb/version"
-require "mongo-parser-rb/exceptions"
-require "mongo-parser-rb/field"
-require "mongo-parser-rb/query/expression"
-require "mongo-parser-rb/query"
+require_relative "mongo-parser-rb/version"
+require_relative "mongo-parser-rb/exceptions"
+require_relative "mongo-parser-rb/field"
+require_relative "mongo-parser-rb/query/expression"
+require_relative "mongo-parser-rb/query"
 
 module MongoParserRB
 end

--- a/lib/mongo-parser-rb/query.rb
+++ b/lib/mongo-parser-rb/query.rb
@@ -33,7 +33,7 @@ module MongoParserRB
       raise NotParsedError, "Query not parsed (run parse!)" if @expression_tree.nil?
       @expression_tree.evaluate(document)
     end
-    
+
     private
 
     def parse_root_expression(query, field = nil)
@@ -43,17 +43,17 @@ module MongoParserRB
     end
 
     def parse_sub_expression(key, value, field = nil)
-      if Expression.operator?(key)
-        case key 
-        when *Expression.conjunction_operators
+      if Expression::ALL_OPERATORS.include?(key)
+        case key
+        when *Expression::CONJUNCTION_OPERATORS
           Expression.new(key, value.map { |v| parse_root_expression(v) })
-        when *Expression.inversion_operators
+        when *Expression::INVERSION_OPERATORS
           if value.kind_of?(Hash)
             Expression.new(:$not, field, parse_root_expression(value, field))
           else
             Expression.new(:$not, field, Expression.new(:$eq, field, value))
           end
-        when *Expression.elemMatch_operators
+        when *Expression::ELEM_MATCH_OPERATORS
           Expression.new(:$elemMatch, field, value.to_a.map do |(key, value)|
             parse_sub_expression(key, value)
           end)

--- a/lib/mongo-parser-rb/query/expression.rb
+++ b/lib/mongo-parser-rb/query/expression.rb
@@ -2,71 +2,17 @@ module MongoParserRB
   class Query
     class Expression
 
-      class << self
-
-        def inversion_operators
-          @inversion_operators ||= [
-            :$not
-          ]
-        end
-
-        def inversion_operator?(operator)
-          inversion_operators.include?(operator)
-        end
-
-        def conjunction_operators
-          @conjunction_operators ||= [
-            :$and,
-            :$or
-          ]
-        end
-
-        def conjunction_operator?(operator)
-          conjunction_operators.include?(operator)
-        end
-
-        def negative_equality_operators
-          @negative_equality_operators ||= [
-            :$nin,
-            :$ne
-          ]
-        end
-
-        def equality_operators
-          @equality_operators ||= [
-            :$eq,
-            :$gt,
-            :$lt,
-            :$gte,
-            :$lte,
-            :$in
-          ] | negative_equality_operators
-        end
-
-        def equality_operator?(operator)
-          equality_operators.include?(operator)
-        end
-        
-        def elemMatch_operators
-          @elemMatch_operators ||= [
-            :$elemMatch
-          ]
-        end
-        
-        def elemMatch_operator?(operator)
-          elemMatch_operators.include?(operator)
-        end
-
-        def operator?(operator)
-          equality_operator?(operator) || conjunction_operator?(operator) || inversion_operator?(operator) || elemMatch_operator?(operator)
-        end
-
-      end
+      INVERSION_OPERATORS = [:$not].freeze
+      CONJUNCTION_OPERATORS = [:$and, :$or].freeze
+      NEGATIVE_EQUALITY_OPERATORS = [:$nin, :$ne].freeze
+      EQUALITY_OPERATORS = [:$eq, :$gt, :$lt, :$gte, :$lte, :$in, :$nin, :$ne].freeze
+      ELEM_MATCH_OPERATORS = [:$elemMatch].freeze
+      ALL_OPERATORS = [:$eq, :$gt, :$lt, :$gte, :$lte, :$in, :$nin, :$ne, :$and, :$or, :$not, :$elemMatch].freeze
 
       def initialize(operator, *args)
         @operator = operator
 
-        if Expression.conjunction_operator?(@operator)
+        if CONJUNCTION_OPERATORS.include?(@operator)
           @arguments = args[0]
         else
           @field = Field.new(args[0])
@@ -76,15 +22,15 @@ module MongoParserRB
 
       def evaluate(document)
         case @operator
-        when *Expression.conjunction_operators
+        when *Expression::CONJUNCTION_OPERATORS
           evaluate_conjunction(document)
-        when *Expression.negative_equality_operators
+        when *Expression::NEGATIVE_EQUALITY_OPERATORS
           evaluate_negative_equality(document)
-        when *Expression.equality_operators
+        when *Expression::EQUALITY_OPERATORS
           evaluate_equality(document)
-        when *Expression.inversion_operators
+        when *Expression::INVERSION_OPERATORS
           evaluate_inversion(document)
-        when *Expression.elemMatch_operators
+        when *Expression::ELEM_MATCH_OPERATORS
           evaluate_elemMatch(document)
         end
       rescue NoMethodError, TypeError
@@ -100,7 +46,7 @@ module MongoParserRB
           end
         end
       end
-      
+
       def evaluate_inversion(document)
         # Mongo negative equality operators return true when
         # the specified field does not exist on a document.
@@ -130,8 +76,7 @@ module MongoParserRB
           # the specified field does not exist on a document.
           return true if !value_for_field && !@field.in_document?(document)
 
-          if value_for_field.kind_of?(Array) && 
-             !@arguments.kind_of?(Array)
+          if value_for_field.kind_of?(Array) && !@arguments.kind_of?(Array)
             !value_for_field.include?(@arguments)
           else
             value_for_field != @arguments
@@ -152,8 +97,7 @@ module MongoParserRB
         when :$eq
           if @arguments.kind_of?(Regexp)
             !!(value_for_field =~ @arguments)
-          elsif value_for_field.kind_of?(Array) && 
-                !@arguments.kind_of?(Array)
+          elsif value_for_field.kind_of?(Array) && !@arguments.kind_of?(Array)
             value_for_field.include?(@arguments)
           else
             value_for_field == @arguments

--- a/performance/perf.rb
+++ b/performance/perf.rb
@@ -1,0 +1,49 @@
+require 'benchmark'
+require_relative '../lib/mongo-parser-rb'
+
+iterations = 500_000
+
+Benchmark.bm(22) do |bm|
+  bm.report('simple query parsing') do
+    query_hash = {
+      :$or => [
+        { aaa: { :$gt => 20 } },
+        { bbb: {:$not => {:$gt => 10 }} },
+        { ccc: 11 },
+        { ddd: 12 },
+        { eee: 13 },
+        { :fff => { :$in => [1] } }
+      ]
+    }
+
+    iterations.times do
+      MongoParserRB::Query.parse(query_hash)
+    end
+  end
+
+  bm.report('simple query matching') do
+    query = MongoParserRB::Query.parse({
+      :$or => [
+        { aaa: { :$gt => 20 } },
+        { bbb: 10 },
+        { ccc: 11 },
+        { ddd: 12 },
+        { eee: 13 }
+      ]
+    })
+
+    document = {
+      aaa: 1, bbb: 2, ccc: 3, ddd: 4, eee: 5,
+      nested1: {
+        aaa: 1, bbb: 2, ccc: 3, ddd: 4, eee: 5,
+        nested: {
+          aaa: 1, bbb: 2, ccc: 3, ddd: 4, eee: 5
+        }
+      }
+    }
+
+    iterations.times do
+      query.matches_document?(document)
+    end
+  end
+end


### PR DESCRIPTION
I'll rebase this once https://github.com/intercom/mongo-parser-rb/pull/10 has merged to remove the perf changes.

**before**

```
simple query parsing    18.300000   0.030000  18.330000 ( 18.464194)
simple query matching   42.060000   0.080000  42.140000 ( 42.321371)
```

**after**

```
➜  mongo-parser-rb git:(gj/query-parser-perf) rake perf
                             user     system      total        real
simple query parsing    13.550000   0.020000  13.570000 ( 13.619612)
simple query matching   40.870000   0.100000  40.970000 ( 41.278397)
```

/cc @dehora @ciaranlee 